### PR TITLE
PHP >= 7 compatibility warnings

### DIFF
--- a/classes/class.p3-profiler-plugin.php
+++ b/classes/class.p3-profiler-plugin.php
@@ -7,7 +7,7 @@
  * @package P3_Profiler
  */
 class P3_Profiler_Plugin {
-	
+
 	/**
 	 * Add the 'P3 Profiler' option under the 'Tools' menu
 	 */
@@ -17,7 +17,7 @@ class P3_Profiler_Plugin {
 			__( 'P3 Plugin Profiler', 'p3-profiler' ),
 			'manage_options',
 			P3_PLUGIN_SLUG,
-			array( 'P3_Profiler_Plugin_Admin', 'dispatcher' )				
+			array( 'P3_Profiler_Plugin_Admin', 'dispatcher' )
 		);
 	}
 
@@ -42,7 +42,7 @@ class P3_Profiler_Plugin {
 	 */
 	public static function activate() {
 		global $wp_version;
-		
+
 		// Version check, only 3.3+
 		if ( ! version_compare( $wp_version, '3.3', '>=' ) ) {
 			if ( function_exists( 'deactivate_plugins' ) )
@@ -50,7 +50,7 @@ class P3_Profiler_Plugin {
 			die( '<strong>P3</strong> requires WordPress 3.3 or later' );
 		}
 
-		// mu-plugins doesn't exist	
+		// mu-plugins doesn't exist
 		if ( !file_exists( WPMU_PLUGIN_DIR ) && is_writable( dirname( WPMU_PLUGIN_DIR ) ) ) {
 			wp_mkdir_p( WPMU_PLUGIN_DIR );
 		}
@@ -60,6 +60,14 @@ class P3_Profiler_Plugin {
 				'<' . "?php // Start profiling\n@include_once( WP_PLUGIN_DIR . '/p3-profiler/start-profile.php' ); ?" . '>'
 			);
 		}
+
+		// PHP >= 7 Compatibility Notice
+		if ( version_compare( PHP_VERSION, '7.0.0', '>=' ) ) {
+			if ( function_exists( 'deactivate_plugins' ) ) {
+				die( '<strong>P3</strong> is not compatible with PHP 7.0.0 or later.' );
+			}
+		}
+
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Godaddy, StarfieldTech, kurtpayne, asink
 Tags: debug, debugging, developer, development, performance, plugin, profiler, speed
 Requires at least: 3.3
-Tested up to: 4.7.2
+Tested up to: 4.6
 Stable tag: 1.5.3.9
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -10,6 +10,9 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 See which plugins are slowing down your site.  This plugin creates a performance report for your site.
 
 == Description ==
+
+> <strong>Important:</strong> P3 is not compatible with PHP 7.0.0 or later
+
 This plugin creates a profile of your WordPress site's plugins' performance by measuring their impact on your site's load time.  Often times, WordPress sites load slowly because of poorly configured plugins or because there are so many of them. By using the P3 plugin, you can narrow down anything causing slowness on your site.
 
 This plugin uses the canvas element for drawing charts and requires requires Firefox, Chrome, Opera, Safari, or IE9 or later.  This plugin will not work in IE8 or lower.


### PR DESCRIPTION
* Added notice and prevent plugin activation when on a site running PHP >= 7.
* Added notice to readme.txt.
* Downgrade tested up to version to 4.6 to maintain WordPress.org notice.